### PR TITLE
Added --region flag in uninstall guide

### DIFF
--- a/_documentation/uninstall-convox.md
+++ b/_documentation/uninstall-convox.md
@@ -5,7 +5,7 @@ Your rack can be uninstalled using the CLI. AWS credentials are required for thi
 
     $ convox uninstall
 
-You may specify the region your cluster is installed in with the option --region (defaults to us-east-1):
+You may specify the region of your cluster with `--region` (defaults to `us-east-1`):
 
     $ convox uninstall --region your-cluster-region
 


### PR DESCRIPTION
The uninstall guide was missing an explanation of the --region flag.
